### PR TITLE
Add fallback entry template with it's own layout priority list.

### DIFF
--- a/BladeTemplateLoader.php
+++ b/BladeTemplateLoader.php
@@ -96,16 +96,17 @@ class BladeTemplateLoader
 
         $template = $this->locateTemplate($filter_templates);
 
-        if ($template) {
-            $this->data = collect(get_body_class())->reduce(function ($data, $class) use ($template) {
-                return apply_filters("sage/template/{$class}/data", $data, $template);
-            }, []);
-            echo \App\template($template, $this->data);
-            // Return the empty index.php in Sage to make WooCommerce happy
-            return ['index.php'];
+        if (!$template) {
+            $template = FallbackTemplate::getEntry();
         }
 
-        return $search_files;
+        $this->data = collect(get_body_class())->reduce(function ($data, $class) use ($template) {
+            return apply_filters("sage/template/{$class}/data", $data, $template);
+        }, []);
+        echo \App\template($template, $this->data);
+
+        // Return the empty index.php in Sage to make WooCommerce happy
+        return ['index.php'];
     }
 
     /**
@@ -130,7 +131,6 @@ class BladeTemplateLoader
 
         $paths = [
             trim(WC()->template_path(), '/\\'),
-            'partials',
         ];
 
         $filter_templates = $this->filterTemplates($template_parts, $paths);

--- a/FallbackTemplate.php
+++ b/FallbackTemplate.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Kimhf\SageWoocommerceSupport;
+
+/**
+ * Add support for fallback blade templates.
+ */
+class FallbackTemplate
+{
+    /**
+     * Add the blade namespace to the view finder.
+     *
+     * @return void
+     */
+    public static function getEntry()
+    {
+        \App\sage('view.finder')->addNamespace('SWS', __DIR__ . '\views');
+
+        return 'SWS::woocommerce';
+    }
+
+    /**
+     * Get fallback view if not found in theme.
+     *
+     * @return mixed
+     */
+    public static function getBladeView($view) : string
+    {
+        $namespace = '';
+        if (! \App\locate_template($view)) {
+            $namespace = 'SWS::';
+        }
+
+        return $namespace . $view;
+    }
+
+    /**
+     * Get default blade layout.
+     *
+     * @return string
+     */
+    public static function getBladeLayout() : string
+    {
+        $search_layouts = [
+            "layouts/woocommerce",
+            "layouts/app",
+        ];
+
+        foreach ($search_layouts as $search_layout) {
+            if (\App\locate_template($search_layout)) {
+                return $search_layout;
+            }
+        }
+
+        return 'SWS::layouts.fallback';
+    }
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,6 +6,7 @@
   <file>.</file>
 
   <exclude-pattern>vendor/</exclude-pattern>
+  <exclude-pattern>views/</exclude-pattern>
 
   <!-- Show colors in console -->
   <arg value="-colors"/>

--- a/views/layouts/fallback.blade.php
+++ b/views/layouts/fallback.blade.php
@@ -1,0 +1,18 @@
+<!doctype html>
+<html {!! get_language_attributes() !!}>
+  @include(\Kimhf\SageWoocommerceSupport\FallbackTemplate::getBladeView('partials/head'))
+  <body @php body_class() @endphp>
+    @php do_action('get_header') @endphp
+    @include(\Kimhf\SageWoocommerceSupport\FallbackTemplate::getBladeView('partials/header'))
+    <div class="wrap container" role="document">
+      <div class="content">
+        <main class="main">
+          @yield('content')
+        </main>
+      </div>
+    </div>
+    @php do_action('get_footer') @endphp
+    @include(\Kimhf\SageWoocommerceSupport\FallbackTemplate::getBladeView('partials/footer'))
+    @php wp_footer() @endphp
+  </body>
+</html>

--- a/views/partials/footer.blade.php
+++ b/views/partials/footer.blade.php
@@ -1,0 +1,5 @@
+<footer class="content-info">
+  <div class="container">
+    @php dynamic_sidebar('sidebar-footer') @endphp
+  </div>
+</footer>

--- a/views/partials/head.blade.php
+++ b/views/partials/head.blade.php
@@ -1,0 +1,6 @@
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  @php wp_head() @endphp
+</head>

--- a/views/partials/header.blade.php
+++ b/views/partials/header.blade.php
@@ -1,0 +1,10 @@
+<header class="banner">
+  <div class="container">
+    <a class="brand" href="{{ home_url('/') }}">{{ get_bloginfo('name', 'display') }}</a>
+    <nav class="nav-primary">
+      @if (has_nav_menu('primary_navigation'))
+        {!! wp_nav_menu(['theme_location' => 'primary_navigation', 'menu_class' => 'nav']) !!}
+      @endif
+    </nav>
+  </div>
+</header>

--- a/views/woocommerce.blade.php
+++ b/views/woocommerce.blade.php
@@ -1,0 +1,5 @@
+@extends(\Kimhf\SageWoocommerceSupport\FallbackTemplate::getBladeLayout())
+
+@section('content')
+	@php(woocommerce_content())
+@endsection


### PR DESCRIPTION
If there are no appropriate WooCommerce template in the theme, a generic fallback template will load instead. This will use the first layout available from this list:

1. layouts/woocommerce
2. layouts/app
3. a basic fallback layout that again has fallbacks for head, header and footer

Bottom line is when sage-woocommerce-support is added the theme should support WooCommerce without the need to do anything else. Any additional adjustments and customization is completely optional.

One breaking change: wc_get_template_part() no longer looks for templates in the partials folder.