### PR TITLE
Changed inline @php directive to full form #2042

### DIFF
--- a/src/views/woocommerce.blade.php
+++ b/src/views/woocommerce.blade.php
@@ -1,5 +1,5 @@
 @extends(\Kimhf\SageWoocommerceSupport\get_blade_layout())
 
 @section('content')
-	@php(woocommerce_content())
+	@php woocommerce_content() @endphp
 @endsection


### PR DESCRIPTION
Since Sage 9.0.1 there is a [change to the inline @php directive](https://github.com/roots/sage/pull/2042).